### PR TITLE
ポスト投稿機能の実装

### DIFF
--- a/app/assets/stylesheets/sidebars.css
+++ b/app/assets/stylesheets/sidebars.css
@@ -9,7 +9,7 @@
   /* サイドバーの表示優先順位をつける */
   z-index: 100;
   /* サイドバーの上に余白をつける */
-  padding: 90px 0 0;
+  padding: 50px 0 0;
   /* サイドバーに影をつける */
   box-shadow: inset -1px 0 0 rgba(0, 0, 0, .1);
   z-index: 99;

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,0 +1,31 @@
+class PostsController < ApplicationController
+  def new
+    @post = Post.new
+  end
+
+  def create
+    # 入力されたフォーム内容を元にUser型で宣言
+    @post = current_user.posts.new(post_params)
+    tag_names = params[:post][:tag].split(",")
+
+    # 新規登録の処理(フォームが正しく入力され、DBに保存できるか)
+    if @post.save
+      # タグの保存処理、"model/post"で処理を行う
+      @post.save_tags(tag_names)
+      # ポスト投稿完了後、トップページに戻る
+      redirect_to root_path, success: t(".success_post")
+    else
+      flash.now[:danger] = t(".error_post")
+      # Rails7で搭載されているTurbo対策用にstatusを設定、これがないとバリデーション失敗時のエラーが表示されない
+      render :new, status: :unprocessable_entity
+    end
+  end
+
+  def destroy; end
+
+  private
+
+  def post_params
+    params.require(:post).permit(:movie_url, :comment)
+  end
+end

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -1,0 +1,2 @@
+module PostsHelper
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,36 @@
+class Post < ApplicationRecord
+  # Userテーブルと関連
+  belongs_to :user
+  # ポストが削除されたら中間テーブルpost_tagsの関連データも削除
+  has_many :post_tags, dependent: :destroy
+  # 中間テーブルpost_tagsを通してtagsと関連
+  has_many :tags, through: :post_tags
+
+  # 動画URL、コメントのモデル設定
+  validates :movie_url, presence: true, length: { maximum: 255 }
+  validates :comment, presence: true, length: { maximum: 255 }
+
+  # カスタムバリデーションの設定、正しくURL入力されてるかチェック
+  validate :url_check
+
+  def url_check
+    # 正しいURLで入力されているかどうか、一応ライブ動画も対応
+    if !movie_url.start_with?("https://youtu.be/") && !movie_url.start_with?("https://www.youtube.com/live/")
+      errors.add(:movie_url, "正しい入力ではありません") # save失敗のためにerror文、メッセージ対応は後で
+    end
+  end
+
+  # タグ保存用のメソッド(Toxi法と呼ぶらしい)
+  def save_tags(tag_names)
+    tag_names.each do |tagname|
+      # テーブルTagに保存、タグが重複があれば保存しない
+      post_tag = Tag.find_or_create_by(name: tagname)
+      # 中間テーブルPost_Tagに保存、こちらも重複があれば保存しない
+      self.tags << post_tag
+
+      # if !self.tags.find_by(name: post_tag.name)
+      #   self.tags << post_tag
+      # end
+    end
+  end
+end

--- a/app/models/post_tag.rb
+++ b/app/models/post_tag.rb
@@ -1,0 +1,5 @@
+class PostTag < ApplicationRecord
+  # Post、Tagテーブルと関連
+  belongs_to :post
+  belongs_to :tag
+end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,0 +1,9 @@
+class Tag < ApplicationRecord
+  # ポストが削除されたら中間テーブルpost_tagsの関連データも削除
+  has_many :post_tags, dependent: :destroy
+  # 中間テーブルpost_tagsを通してpostsと関連
+  has_many :posts, through: :post_tags
+
+  # ぶっちゃけいらないかもだけど念のためバリデーションを作成
+  validates :name, presence: true, length: { maximum: 255 }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
   authenticates_with_sorcery!
 
+  # ポストと関連付け、このユーザーが削除されたらポストも削除
+  has_many :posts, dependent: :destroy
+
   # パスワード入力用
   # 新規ユーザー登録、パスワード変更の際に入力されたパスワードが正しいか
   validates :password, length: { minimum: 3 }, if: -> { new_record? || changes[:crypted_password] }

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,15 @@
+<h1>ポスト画面</h1>
+
+<%= form_with model: @post do |form| %>
+  <%= form.label :movie_url, style: "display: block" %>
+  <%= form.text_field :movie_url %>
+  <%= form.label :comment, style: "display: block" %>
+  <%= form.text_area :comment, cols: 30, rows: 5, style: "resize: none;" %>
+  <%= form.label :tag, style: "display: block" %>
+  <%= form.text_field :tag %>
+
+  <div style="display: block;">
+    <%= form.submit t('.submit') %>
+  </div>
+<% end %>
+

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -22,8 +22,8 @@
         <%= form.label :introduction, style: "display: block" %>
         <%= form.text_area :introduction, class: "mb-2", cols: 30, rows: 5, style: "resize: none;"%>
       </div>
-      <div style="display: inline-block;">
-        <%= form.submit "変更" %>
+      <div style="display: block;">
+        <%= form.submit t('.change') %>
       </div>
     </div>
   </div>

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -16,7 +16,7 @@
     <% if @user.id == current_user.id %>
       <%= link_to t('.edit'), edit_profile_path(current_user.id), class: "btn btn-primary" %>
     <% else %>
-      <%= link_to "フォロー", "#", class: "btn btn-light" %>
+      <%= link_to t('.follow'), "#", class: "btn btn-light" %>
     <% end %>
   </div>
 </div>

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -1,12 +1,18 @@
 <!-- サイドバー表示用、本リリースでサイドバー実装を行う予定 -->
 <nav id="sidebar" class="col-lg-2 d-md-block sidebar collapse">
   <div class="position-sticky pt-md-5">
-    <ul class="nav flex-column">
+    <ul class="nav flex-column d-flex">
+      <% if logged_in? %>
+        <div class="post" style="text-align: center;">
+          <%= link_to t('sidebar.post'), new_post_path, class: "btn btn-primary", style: "width: 70%;" %>
+        </div>
+      <% end %>
       <li class="nav-item">
         <a class="nav-link" href="#">
           <span class="ml-2">Coming soon...</span>
         </a>
       </li>
+
       <!-- サンプルコード(サイドバー実装時にまた触る)
       <li class="nav-item">
         <a class="nav-link active" aria-current="page" href="#">
@@ -21,6 +27,7 @@
         </a>
       </li>
       -->
+
     </ul>
   </div>
 </nav>

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -12,3 +12,7 @@ ja:
         introduction: 自己紹介
         favorite_game: お気に入りのゲーム
         google_acount: Googleアカウント
+      post:
+        movie_url: 動画URL
+        comment: コメント
+        tag: タグ

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -58,11 +58,18 @@ ja:
     show:
       title: プロフィール
       edit: 編集
+      follow: フォロー
+    edit:
+      change: 変更
+  posts:
+    new:
+      submit: 投稿
+    create:
+      success_post: ポストを投稿しました
+      error_post: 投稿失敗しました
   header:
     login: ログイン
     logout: ログアウト
-    board: 掲示板
-    board_index: 掲示板一覧
-    create_board: 掲示板作成
-    bookmark_index: ブックマーク一覧
-    profile: プロフィール
+    search: 検索
+  sidebar:
+    post: 投稿

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,8 @@ Rails.application.routes.draw do
   resources :profiles, only: %i[show edit update destroy]
   # 設定画面のルーティング設定
   resources :settings, only: %i[edit update destroy]
+  # ポスト画面のルーティング設定
+  resources :posts, only: %i[new create destroy]
 
   # ↓ここからは生成された時からあるもの
   # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html

--- a/db/migrate/20250215110759_create_post.rb
+++ b/db/migrate/20250215110759_create_post.rb
@@ -1,0 +1,12 @@
+class CreatePost < ActiveRecord::Migration[7.2]
+  def change
+    create_table :posts do |t|
+      t.references :user, foreign_key: true # ポストの投稿者、usersから取得
+      t.string :movie_url, null: false # 動画のURL
+      t.string :comment, null: false # ポストのコメント内容
+      t.integer :view_count, default: 0 # ポストの閲覧回数
+
+      t.timestamps # 作成日時のデータだけ使う
+    end
+  end
+end

--- a/db/migrate/20250215112016_create_tag.rb
+++ b/db/migrate/20250215112016_create_tag.rb
@@ -1,0 +1,8 @@
+class CreateTag < ActiveRecord::Migration[7.2]
+  def change
+    create_table :tags do |t|
+      t.string :name # タグの名前
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250215112041_create_post_tag.rb
+++ b/db/migrate/20250215112041_create_post_tag.rb
@@ -1,0 +1,10 @@
+class CreatePostTag < ActiveRecord::Migration[7.2]
+  def change
+    create_table :post_tags do |t|
+      t.references :post, foreign_key: true # Postのデータを関連付ける
+      t.references :tag, foreign_key: true # Tagのデータを関連付ける
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250215112947_create_history.rb
+++ b/db/migrate/20250215112947_create_history.rb
@@ -1,0 +1,10 @@
+class CreateHistory < ActiveRecord::Migration[7.2]
+  def change
+    create_table :histories do |t|
+      t.references :user, foreign_key: true # Userのデータを関連付ける
+      t.references :post, foreign_key: true # Postのデータを関連付ける
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,9 +10,43 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_09_065237) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_15_112947) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "histories", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "post_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_histories_on_post_id"
+    t.index ["user_id"], name: "index_histories_on_user_id"
+  end
+
+  create_table "post_tags", force: :cascade do |t|
+    t.bigint "post_id"
+    t.bigint "tag_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["post_id"], name: "index_post_tags_on_post_id"
+    t.index ["tag_id"], name: "index_post_tags_on_tag_id"
+  end
+
+  create_table "posts", force: :cascade do |t|
+    t.bigint "user_id"
+    t.string "movie_url", null: false
+    t.string "comment", null: false
+    t.integer "view_count", default: 0
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_posts_on_user_id"
+  end
+
+  create_table "tags", force: :cascade do |t|
+    t.string "name"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
@@ -32,4 +66,10 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_09_065237) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "histories", "posts"
+  add_foreign_key "histories", "users"
+  add_foreign_key "post_tags", "posts"
+  add_foreign_key "post_tags", "tags"
+  add_foreign_key "posts", "users"
 end

--- a/test/controllers/posts_controller_test.rb
+++ b/test/controllers/posts_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostsControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/fixtures/post_tags.yml
+++ b/test/fixtures/post_tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/posts.yml
+++ b/test/fixtures/posts.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/tags.yml
+++ b/test/fixtures/tags.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/post_tag_test.rb
+++ b/test/models/post_tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/post_test.rb
+++ b/test/models/post_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class PostTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/tag_test.rb
+++ b/test/models/tag_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class TagTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
・概要
動画URL、コメント、タグを含めたポストを投稿する機能を追加。
ただしポストを表示する機能はまだ実装していない為、データベース上の保存までしか実行していない。
タグ入力フォームで文字列の間に「,」と記載することで、複数のタグを設定することができる。
また、サイドバーにてログイン中のみ「投稿」ボタンを表示させることで、ポスト投稿画面に誘導できるようにしている。

・確認方法
ログインを行った後、サイドバーに「投稿」と表示されるのでそちらをクリック。
投稿画面で動画URL、コメント、タグを入力して投稿を押す。
動画URL、コメントは必須、また動画URLは正しくYouTubeのリンクが記載されていなければ投稿失敗する処理が出来ていることを確認する。

・メモ
本来であればポストにどんなゲームなのか情報を載せるつもりではいたが、
その場合ゲーム名を正確に記載しないといけない関係上、何も考えず実装するとユーザーにとって煩わしい機能になるのではないかと予想。
もし実装する場合であれば「ほとんどのゲーム名を入れたテーブルを用意し、そこからフォーム入力すると検索候補が表示される機能」、
もしくは「共有予定のYouTube動画で設定されたゲーム名を取得する機能」のどちらかを実装しないといけなければならない為、現時点ではテーブルに追加していない。

なのでゲーム名の追加についてはいったん本リリース時に行うことで保留。
場合によってはタグ機能で簡易的に代用し、実装そのものを見送る可能性がある。