### PR TITLE
ポスト削除機能を実装

### DIFF
--- a/app/assets/stylesheets/mains.css
+++ b/app/assets/stylesheets/mains.css
@@ -110,8 +110,8 @@
   /*---------- share/_postで使用 -----------*/
 
   .card{
-    width: 95%;
-    margin: 10px auto;
+    width: 80%;
+    margin: 20px auto;
     box-shadow: 2px 2px 3px;
   }
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -21,7 +21,10 @@ class PostsController < ApplicationController
     end
   end
 
-  def destroy; end
+  def destroy
+    Post.find_by(id: params[:id]).destroy
+    redirect_to profile_path(current_user.id), info: t(".delete.delete_post")
+  end
 
   private
 

--- a/app/views/profiles/show.html.erb
+++ b/app/views/profiles/show.html.erb
@@ -13,7 +13,7 @@
     <p>○○人のフォロワー</p>
   </div>
   <div class="button">
-    <% if @user.id == current_user.id %>
+    <% if logged_in? && @user.id == current_user.id %>
       <%= link_to t('.edit'), edit_profile_path(current_user.id), class: "btn btn-primary" %>
     <% else %>
       <%= link_to t('.follow'), "#", class: "btn btn-light" %>

--- a/app/views/shared/_post.html.erb
+++ b/app/views/shared/_post.html.erb
@@ -14,9 +14,8 @@
       </div>
     </div>
     <!-- コメント、タイトルなどの表示 -->
-    <div class="col-md-9">
+    <div class="col-md-7">
       <div class="card-body d-flex flex-column" style="padding: 10px; height: 100%;">
-
         <!-- ユーザーの表示 -->
         <%= link_to profile_path(post.user.id), style: "text-decoration: none; color: inherit;" do %>
           <div class="card-user d-flex">
@@ -47,6 +46,14 @@
           <%= postview_count(post) %>
         </div>
       </div>
+    </div>
+
+    <div class="col-md-2 d-flex" style="justify-content: flex-end; align-items: center;">
+      <% if logged_in? && request.path == profile_path(current_user.id) %>
+        <div class="delete-button" style="margin-right: 10%">
+          <%= link_to "削除", post_path(post.id), class: "btn btn-danger" ,  data: { turbo_method: :delete, turbo_confirm: "ポストを削除しますか？" }%>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -67,6 +67,8 @@ ja:
     create:
       success_post: ポストを投稿しました
       error_post: 投稿失敗しました
+    delete:
+      delete_post: ポストを削除しました
   header:
     login: ログイン
     logout: ログアウト


### PR DESCRIPTION
・概要
ログインしているユーザーが自身のプロフィール画面を開いた時のみ削除ボタンを表示させ、ポスト削除機能を実装。
これにより自身のポストを削除することが出来るようになった。

プロフィール画面のみ表示させた理由として、検索画面で自身のポストがヒットした際に削除ボタンを表示させるのはユーザー目線的に邪魔になると思ったから。

・確認方法
ログインを行った後、自身のプロフィール画面に遷移する。
ポストを投稿していればポスト右側に削除ボタンが表示されることを確認する。
削除ボタンを押して「ポストを削除しますか？」と確認メッセージを承諾したら、
自身のプロフィール画面にリダイレクトされ、ポストが削除されていることを確認。

・メモ
デプロイしているときに今さらながら気づいたが、fly.ioで借りているスペックが予想よりオーバースペック気味だった。
メモリを約1GBも使用していたため、設定でメモリを4分の1にまで縮小した。
恐らくないとは思うが、メモリ不足により何らかのエラーが発生したらまたこの設定を見返そうと思う。