### PR TITLE
本番環境でメールを送信

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -81,6 +81,21 @@ Rails.application.configure do
   # caching is enabled.
   config.action_mailer.perform_caching = false
 
+  # 本番環境でGmailを利用してメール送信
+  config.action_mailer.default_url_options = {  host: "portfolio-makzxa.fly.dev" }
+  config.action_mailer.raise_delivery_errors = true
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              "smtp.gmail.com",
+    port:                 587,
+    domain:               "omoro.com",
+    user_name:            ENV["GMAIL_USERNAME"],
+    password:             ENV["GMAIL_PASSWORD"],
+    authentication:       "plain",
+    enable_starttls_auto: true
+  }
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
@@ -89,7 +104,7 @@ Rails.application.configure do
   # the I18n.default_locale when a translation cannot be found).
   config.i18n.fallbacks = true
 
-  # Don't log any deprecations.
+  # Don"t log any deprecations.
   config.active_support.report_deprecations = false
 
   # Do not dump schema after migrations.


### PR DESCRIPTION
・概要
本番環境でパスワードリセット用のメールが送信されたことを確認。
gmailで新しくパスワードリセット用のお知らせメールを送信するアカウントを作成し、入力されたメールアドレスが登録済のユーザーであればメール送信されることを確認した。

これによって本番環境でもパスワードリセットが出来るように整えられた。

・メモ
まだドメイン名を取得していない為、メール内に含まれるURLのホストを「portfolio-makzxa.fly.dev」と設定している。
実際にドメイン名を取得して公開する際、ここを必ず直すこと。