### PR TITLE
細かいエラーメッセージの追加

### DIFF
--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -1,5 +1,6 @@
 class LoginsController < ApplicationController
   def new
+    @user = User.new
   end
 
   def create

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -15,8 +15,10 @@ class Post < ApplicationRecord
 
   def url_check
     # 正しいURLで入力されているかどうか、一応ライブ動画も対応
-    if !movie_url.start_with?("https://youtu.be/") && !movie_url.start_with?("https://www.youtube.com/live/")
-      errors.add(:movie_url, "正しい入力ではありません") # save失敗のためにerror文、メッセージ対応は後で
+    if movie_url.present?
+      if !movie_url.start_with?("https://youtu.be/") && !movie_url.start_with?("https://www.youtube.com/live/")
+        errors.add(:movie_url, "が正しい入力ではありません、YouTubeの共有ボタンからリンクを取得してください") # save失敗のためにerror文、メッセージ対応は後で
+      end
     end
   end
 

--- a/app/views/logins/new.html.erb
+++ b/app/views/logins/new.html.erb
@@ -1,6 +1,6 @@
 <h1><%= t('.title') %></h1>
 
-<%= form_with url: login_path do |form| %>
+<%= form_with model: @user, url: login_path do |form| %>
   <!-- ログイン用のフォーム -->
   <div>
     <%= form.label :email, style: "display: block" %>

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,6 +1,7 @@
 <h1><%= t('.title') %></h1>
 
 <%= form_for @user, :url => password_reset_path(@token), :html => {:method => :put} do |f| %>
+  <%= render 'shared/error_message', object: f.object %>
 
   <!-- 元々あったエラーメッセージ表示用コード、後で見直す時の参考用に
   <% if @user.errors.any? %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,6 +1,7 @@
 <h1>ポスト画面</h1>
 
 <%= form_with model: @post do |form| %>
+  <%= render 'shared/error_message', object: form.object %>
   <%= form.label :movie_url, style: "display: block" %>
   <%= form.text_field :movie_url %>
   <%= form.label :comment, style: "display: block" %>

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,6 +1,7 @@
 <h1>プロフィール設定</h1>
 
 <%= form_with model: @user, url: profile_path do |form| %>
+  <%= render 'shared/error_message', object: form.object %>
   <div class="profile_edit">
     <div class="icon_form">
       <% if @user.icon.present? %>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -1,6 +1,7 @@
 <h1>メールアドレス・パスワード変更</h1>
 
 <%= form_with model: @user, url: setting_path do |form| %>
+  <%= render 'shared/error_message', object: form.object %>
   <div class="Setting_form">
     <%= form.label :email, style: "display: block" %>
     <%= form.text_field :email %>

--- a/app/views/shared/_error_message.html.erb
+++ b/app/views/shared/_error_message.html.erb
@@ -1,0 +1,9 @@
+<% if object.errors.any? %>
+  <div id="error_explanation" class="alert alert-danger">
+    <ul class="mb-0">
+      <% object.errors.each do |error| %>
+        <li><%= error.full_message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,6 +1,7 @@
 <h1><%= t('.title') %></h1>
 
 <%= form_with model: @user do |form| %>
+  <%= render 'shared/error_message', object: form.object %>
   <div>
     <%= form.label :name, style: "display: block" %>
     <%= form.text_field :name, value: params[:name] %>


### PR DESCRIPTION
・概要
ポスト投稿、新規登録、メールアドレスやパスワード変更の失敗した際にどのフォームが原因で失敗したのか、という内容のメッセージを追加。
これによりフォームが失敗した際、何が原因で失敗したのかユーザー目線で分かるようになった。

・確認方法
ポスト投稿で何も入力しない状態でポストを投稿する。
エラーメッセージが表示され、期待する挙動とは違った部分がメッセージとして表示されることを確認する。
