### PR TITLE
フォーム、ポストにあるコメントのUIを修正

### DIFF
--- a/app/assets/stylesheets/mains.css
+++ b/app/assets/stylesheets/mains.css
@@ -112,6 +112,7 @@
   .card{
     width: 80%;
     margin: 20px auto;
+    /* ポストに影をつけておく */
     box-shadow: 2px 2px 3px;
   }
 
@@ -142,4 +143,38 @@
     margin: 0 0 0 3px;
     height: 25px;
     line-height: 25px;
+  }
+
+  .card-comment {
+    /* ポスト内のコメントを3行まで表示させる、溢れた場合は...と表示する */
+    display: -webkit-box;
+    -webkit-line-clamp: 3;
+    -webkit-box-orient: vertical;
+    overflow: hidden; 
+  }
+
+  /*---------- share/_after_loginで使用 -----------*/
+
+  .nav-tabs {
+    width: 100%;
+  }
+  
+  .nav-tabs .nav-item {
+    flex: 1;
+  }
+  
+  .nav-tabs .nav-item .nav-link {
+    width: 100%;
+    text-align: center;
+    
+    .active{
+      background-color: grey;
+    }
+  }
+
+  /*---------- その他 -----------*/
+
+  /* フォームの外枠の色を見やすいように調整*/
+  .form-control{
+    border-color: #3d3d3d;
   }

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -20,6 +20,6 @@ class ApplicationController < ActionController::Base
 
     # Postテーブルから検索し、検索結果を@search_postsに渡す
     @q = Post.ransack(params[:q])
-    @search_posts = @q.result(distinct: true)
+    @search_posts = @q.result(distinct: true).order(created_at: :desc)
   end
 end

--- a/app/controllers/logins_controller.rb
+++ b/app/controllers/logins_controller.rb
@@ -6,7 +6,6 @@ class LoginsController < ApplicationController
   def create
     # 入力されたメールアドレスとパスワードを元にUserテーブル検索
     @user = login(params[:email], params[:password])
-
     # ログイン処理が出来たかどうか(Userテーブルからユーザー情報を取得できていれば)
     if @user.present?
       session[:user_id] = @user.id # Cookie保存用

--- a/app/controllers/profiles_controller.rb
+++ b/app/controllers/profiles_controller.rb
@@ -1,7 +1,7 @@
 class ProfilesController < ApplicationController
   def show
     @user = User.find_by(id: params[:id])
-    @posts = Post.where(user_id: @user.id)
+    @posts = Post.where(user_id: @user.id).order(created_at: :desc)
     @user_follower = @user.follower_user
   end
 

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -17,7 +17,7 @@ class Post < ApplicationRecord
     # 正しいURLで入力されているかどうか、一応ライブ動画も対応
     if movie_url.present?
       if !movie_url.start_with?("https://youtu.be/") && !movie_url.start_with?("https://www.youtube.com/live/")
-        errors.add(:movie_url, "が正しい入力ではありません、YouTubeの共有ボタンからリンクを取得してください") # save失敗のためにerror文、メッセージ対応は後で
+        errors.add(:movie_url, "が正しくありません、YouTubeの共有ボタンからを取得してください") # save失敗のためにerror文、メッセージ対応は後で
       end
     end
   end

--- a/app/views/logins/new.html.erb
+++ b/app/views/logins/new.html.erb
@@ -1,22 +1,26 @@
-<h1><%= t('.title') %></h1>
-
-<%= form_with model: @user, url: login_path do |form| %>
+<div class=" col-md-8 col-lg-6 mx-auto">
+  <h1><%= t('.title') %></h1>
+  <%= form_with url: login_path do |form| %>
   <!-- ログイン用のフォーム -->
-  <div>
-    <%= form.label :email, style: "display: block" %>
-    <%= form.text_field :email %>
-  </div>
+    <div class="mb-3">
+      <%= form.label :email, style: "display: block" %>
+      <%= form.text_field :email, class: "form-control" %>
+    </div>
+    <div class="mb-3">
+      <%= form.label :password, style: "display: block" %>
+      <%= form.password_field :password, class: "form-control" %>
+    </div>
+    <!-- ログイン用のボタン -->
+    <div class="mb-3">
+      <%= form.submit t('.login'), class: "btn btn-primary" %>
+    </div>
+  <% end %>
 
-  <div>
-    <%= form.label :password, style: "display: block" %>
-    <%= form.password_field :password %>
-  </div>
+  <!-- 新規登録用のリンク -->
+  <%= link_to t('.new_registration'), new_user_path %>
+  <!-- パスワードリセット用のリンク -->
+  <%= link_to t('.password_forget'), new_password_reset_path %>
 
-  <!-- ログイン用のボタン -->
-  <%= form.submit t('.login') %>
-<% end %>
+</div>
 
-<!-- 新規登録用のリンク -->
-<%= link_to t('.new_registration'), new_user_path %>
-<!-- パスワードリセット用のリンク -->
-<%= link_to t('.password_forget'), new_password_reset_path %>
+

--- a/app/views/password_resets/edit.html.erb
+++ b/app/views/password_resets/edit.html.erb
@@ -1,35 +1,22 @@
-<h1><%= t('.title') %></h1>
-
-<%= form_for @user, :url => password_reset_path(@token), :html => {:method => :put} do |f| %>
-  <%= render 'shared/error_message', object: f.object %>
-
-  <!-- 元々あったエラーメッセージ表示用コード、後で見直す時の参考用に
-  <% if @user.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(@user.errors.count, "error") %> prohibited this user from being saved:</h2>
-    
-      <ul>
-      <% @user.errors.full_messages.each do |msg| %>
-        <li><%= msg %></li>
-      <% end %>
-      </ul>
+<div class=" col-md-8 col-lg-6 mx-auto">
+  <h1><%= t('.title') %></h1>
+  <%= form_for @user, :url => password_reset_path(@token), :html => {:method => :put} do |f| %>
+    <%= render 'shared/error_message', object: f.object %>
+      
+    <div class="field mb-2">
+      <%= f.label :email, style: "display: block" %>
+      <%= @user.email %>
+    </div>
+    <div class="field mb-2">
+      <%= f.label :password %>
+      <%= f.password_field :password, style: "display: block", class: "form-control" %>
+    </div>
+    <div class="field mb-2">
+      <%= f.label :password_confirmation, style: "display: block"  %>
+      <%= f.password_field :password_confirmation, class: "form-control" %>
+    </div>
+    <div class="actions">
+      <%= f.submit t('.change'), class: "btn btn-primary" %>
     </div>
   <% end %>
-  -->
-    
-  <div class="field">
-    <%= f.label :email, style: "display: block" %>
-    <%= @user.email %>
-  </div>
-  <div class="field">
-    <%= f.label :password %>
-    <%= f.password_field :password, style: "display: block" %>
-  </div>
-  <div class="field">
-    <%= f.label :password_confirmation, style: "display: block"  %>
-    <%= f.password_field :password_confirmation %>
-  </div>
-  <div class="actions">
-    <%= f.submit t('.change') %>
-  </div>
-<% end %>
+</div>

--- a/app/views/password_resets/new.html.erb
+++ b/app/views/password_resets/new.html.erb
@@ -1,12 +1,16 @@
-<h1><%= t('.title') %></h1>
+<div class=" col-md-8 col-lg-6 mx-auto">
+  <h1><%= t('.title') %></h1>
 
-<%= form_with url: password_resets_path, local: true, method: :post do |form| %>
-  <div class="field">
-    <%= form.label :email , style: "display: block"%>
-    <%= form.text_field :email %>
+  <%= form_with url: password_resets_path, local: true, method: :post do |form| %>
+    <div class="field">
+      <div class="mb-3">
+        <%= form.label :email , style: "display: block"%>
+        <%= form.text_field :email, class: "form-control" %>
+      </div>
 
-    <div style= "display: block;">
-      <%= form.submit t('.mail_send') %>
+      <div class="mb-3" style="display: block;">
+        <%= form.submit t('.mail_send'), class: "btn btn-primary"  %>
+      </div>
     </div>
-  </div>
-<% end %>
+  <% end %>
+</div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,16 +1,23 @@
-<h1>ポスト画面</h1>
+<div class=" col-md-8 col-lg-6 mx-auto">
+  <h1>新規ポスト投稿</h1>
+  <%= form_with model: @post do |form| %>
+    <%= render 'shared/error_message', object: form.object %>
+    <div class="mb-2">
+      <%= form.label :movie_url, style: "display: block" %>
+      <%= form.text_field :movie_url, class: "form-control", placeholder: 'YouTubeの共有ボタンから取得したURL' %>
+    </div>
+    <div class="mb-2">
+      <%= form.label :comment, style: "display: block" %>
+      <%= form.text_area :comment, cols: 30, rows: 5, style: "resize: none;", class: "form-control", placeholder: '255文字以内まで'  %>
+    </div>
+    <div class="mb-2">
+      <%= form.label :tag, style: "display: block" %>
+      <%= form.text_field :tag, class: "form-control", placeholder: 'タグを複数つける場合、「タグ1,タグ2,タグ3,...」と「,」でタグを分けてください' %>
+    </div>
 
-<%= form_with model: @post do |form| %>
-  <%= render 'shared/error_message', object: form.object %>
-  <%= form.label :movie_url, style: "display: block" %>
-  <%= form.text_field :movie_url %>
-  <%= form.label :comment, style: "display: block" %>
-  <%= form.text_area :comment, cols: 30, rows: 5, style: "resize: none;" %>
-  <%= form.label :tag, style: "display: block" %>
-  <%= form.text_field :tag %>
-
-  <div style="display: block;">
-    <%= form.submit t('.submit') %>
-  </div>
-<% end %>
+    <div style="display: block;">
+      <%= form.submit t('.submit'), class: "btn btn-primary"  %>
+    </div>
+  <% end %>
+</div>
 

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -1,5 +1,5 @@
+<div class=" col-md-10 col-lg-8 mx-auto">
 <h1>プロフィール設定</h1>
-
 <%= form_with model: @user, url: profile_path do |form| %>
   <%= render 'shared/error_message', object: form.object %>
   <div class="profile_edit">
@@ -15,16 +15,16 @@
     </div>
 
     <div class="text_form">
-      <div>
+      <div class="mb-2">
         <%= form.label :name, style: "display: block" %>
-        <%= form.text_field :name, class: "mb-2", size: 29 %>
+        <%= form.text_field :name, class: "form-control" %>
       </div>
-      <div>
+      <div class="mb-2">
         <%= form.label :introduction, style: "display: block" %>
-        <%= form.text_area :introduction, class: "mb-2", cols: 30, rows: 5, style: "resize: none;"%>
+        <%= form.text_area :introduction, cols: 30, rows: 5, style: "resize: none;", class: "form-control" %>
       </div>
       <div style="display: block;">
-        <%= form.submit t('.change') %>
+        <%= form.submit t('.change'), class: "btn btn-primary" %>
       </div>
     </div>
   </div>

--- a/app/views/settings/edit.html.erb
+++ b/app/views/settings/edit.html.erb
@@ -1,20 +1,27 @@
-<h1>メールアドレス・パスワード変更</h1>
+<div class=" col-md-8 col-lg-6 mx-auto">
+  <h1>メールアドレス・パスワード変更</h1>
+  <%= form_with model: @user, url: setting_path do |form| %>
+    <%= render 'shared/error_message', object: form.object %>
+    <div class="Setting_form">
+      <div class="mb-2">
+        <%= form.label :email, style: "display: block" %>
+        <%= form.text_field :email, class: "form-control" %>
+      </div>
+      <div class="mb-2">
+        <%= form.label :password, style: "display: block" %>
+        <%= form.password_field :password, class: "form-control" %>
+      </div>
+      <div class="mb-2">
+        <%= form.label :password_confirmation, style: "display: block" %>
+        <%= form.password_field :password_confirmation, class: "form-control" %>
+      </div>
+    </div>
 
-<%= form_with model: @user, url: setting_path do |form| %>
-  <%= render 'shared/error_message', object: form.object %>
-  <div class="Setting_form">
-    <%= form.label :email, style: "display: block" %>
-    <%= form.text_field :email %>
-    <%= form.label :password, style: "display: block" %>
-    <%= form.password_field :password %>
-    <%= form.label :password_confirmation, style: "display: block" %>
-    <%= form.password_field :password_confirmation, class: "mb-2" %>
-  </div>
-
-  <div style="display: inline-block;">
-    <%= form.submit "変更" %>
-  </div>
-<% end %>
+    <div style="display: inline-block;">
+      <%= form.submit "変更", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>
 
 
 

--- a/app/views/shared/_post.html.erb
+++ b/app/views/shared/_post.html.erb
@@ -35,7 +35,9 @@
         <% end %>
         
         <!-- コメントの表示 -->
-        <p><%= post.comment %></p>
+        <div class="card-comment">
+          <p><%= post.comment %></p>
+        </div>
 
         <!-- タグ、動画タイトル、表示回数、投稿日を下寄せで表示 -->
         <div class="card-other", style="margin-top: auto; font-size: 11px;">

--- a/app/views/top/_after_login.html.erb
+++ b/app/views/top/_after_login.html.erb
@@ -1,10 +1,10 @@
 <ul class="nav nav-tabs">
     <li class="nav-item">
-      <button class="nav-link"  data-bs-toggle="tab" data-bs-target="#new_post" type="button">
+      <button class="nav-link" data-bs-toggle="tab" data-bs-target="#new_post" type="button">
         新規投稿
       </button>
     </li>
-    <li class="nav-item">
+    <li class="nav-item" style="flex: 1;">
       <button class="nav-link active"  data-bs-toggle="tab" data-bs-target="#follow_post" type="button">
         フォロー
       </button>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,29 +1,30 @@
-<h1><%= t('.title') %></h1>
+<div class=" col-md-8 col-lg-6 mx-auto">
+  <h1><%= t('.title') %></h1>
+  <%= form_with model: @user do |form| %>
+    <%= render 'shared/error_message', object: form.object %>
+    <div class="mb-2">
+      <%= form.label :name, style: "display: block" %>
+      <%= form.text_field :name, value: params[:name], class: "form-control" %>
+    </div>
 
-<%= form_with model: @user do |form| %>
-  <%= render 'shared/error_message', object: form.object %>
-  <div>
-    <%= form.label :name, style: "display: block" %>
-    <%= form.text_field :name, value: params[:name] %>
-  </div>
+    <div class="mb-2">
+      <%= form.label :email, style: "display: block" %>
+      <%= form.text_field :email, value: params[:email], class: "form-control" %>
+    </div>
 
-  <div>
-    <%= form.label :email, style: "display: block" %>
-    <%= form.text_field :email, value: params[:email] %>
-  </div>
+    <div class="mb-2">
+      <%= form.label :password, style: "display: block" %>
+      <%= form.password_field :password, class: "form-control" %>
+    </div>
 
-  <div>
-    <%= form.label :password, style: "display: block" %>
-    <%= form.password_field :password %>
-  </div>
+    <div class="mb-2">
+      <%= form.label :password_confirmation, style: "display: block" %>
+      <%= form.password_field :password_confirmation, class: "form-control" %>
+    </div>
 
-  <div>
-    <%= form.label :password_confirmation, style: "display: block" %>
-    <%= form.password_field :password_confirmation %>
-  </div>
+    <div class="mb-2" style="display: inline-block;">
+      <%= form.submit t('.submit'), class: "btn btn-primary" %>
+    </div>
 
-  <div style="display: inline-block;">
-    <%= form.submit t('.submit') %>
-  </div>
-
-<% end %>
+  <% end %>
+</div>


### PR DESCRIPTION
・概要
本サイトで仮実装してきたフォームのUIをBootStrap5に適用。
これに伴い、ログイン画面、新規登録などテキストフォームを入力したサイトのUIを見やすいように修正。
また、ポスト内のコメントが指定された行数を超えた場合は「...」と表示させ、本文がはみ出ないように調整。

・確認方法
ログイン画面、新規登録などで使用されているフォームが、Bootstrapで用意されている'form-control'になっていることを確認。
ポストを投稿する際、コメントが3行を超える内容であった場合は「...」と表示され、コメントがはみ出ないことを確認。