### PR TITLE
独自ドメインの取得

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -82,14 +82,14 @@ Rails.application.configure do
   config.action_mailer.perform_caching = false
 
   # 本番環境でGmailを利用してメール送信
-  config.action_mailer.default_url_options = {  host: "portfolio-makzxa.fly.dev" }
+  config.action_mailer.default_url_options = {  host: "omoro-play.com" }
   config.action_mailer.raise_delivery_errors = true
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
     address:              "smtp.gmail.com",
     port:                 587,
-    domain:               "omoro.com",
+    domain:               "omoro-play.com",
     user_name:            ENV["GMAIL_USERNAME"],
     password:             ENV["GMAIL_PASSWORD"],
     authentication:       "plain",


### PR DESCRIPTION
・概要
独自ドメイン「omoro-play.com」を取得し、それに伴いfly.ioでデプロイしたアプリケーションに接続できるようにDNC設定とSSL設定を完了。
これによりomoro-play.comと入力した際、デプロイしたアプリケーションに接続できるようになった。

また独自ドメイン取得に伴い、パスワードリセット時のリンクが独自ドメインを含めたリンクとなるように修正。
これによりパスワードリセットの手続きも問題なく行えることを確認。