### PR TITLE
ポストにゲーム名の情報を追加

### DIFF
--- a/app/assets/stylesheets/mains.css
+++ b/app/assets/stylesheets/mains.css
@@ -109,7 +109,7 @@
   
   /*---------- share/_postで使用 -----------*/
 
-  .card{
+  .postcard{
     width: 80%;
     margin: 20px auto;
     /* ポストに影をつけておく */
@@ -171,6 +171,7 @@
 
   /*---------- share/_after_loginで使用 -----------*/
 
+  /* トップページのタブ表示を整理 */
   .nav-tabs {
     width: 100%;
   }
@@ -187,6 +188,13 @@
       background-color: grey;
     }
   }
+
+  /*---------- posts/newで使用-----------*/
+
+  /* ゲーム検索画面でフォームにカーソルを重ねた際、背景色を変更 */
+  .js-search_result .card:hover{
+    background-color: #f5f5f5;
+}
 
   /*---------- その他 -----------*/
 

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,6 @@
 class PostsController < ApplicationController
+  skip_forgery_protection
+
   def new
     @post = Post.new
   end
@@ -7,11 +9,16 @@ class PostsController < ApplicationController
     # 入力されたフォーム内容を元にUser型で宣言
     @post = current_user.posts.new(post_params)
     tag_names = params[:post][:tag].split(",")
+    game_name = params[:post][:game_name]
+    game_icon = params[:post][:game_icon]
 
     # 新規登録の処理(フォームが正しく入力され、DBに保存できるか)
     if @post.save
       # タグの保存処理、"model/post"で処理を行う
       @post.save_tags(tag_names)
+      # ゲームの保存処理
+      @post.save_game(game_name, game_icon)
+
       # ポスト投稿完了後、トップページに戻る
       redirect_to root_path, success: t(".success_post")
     else
@@ -22,6 +29,7 @@ class PostsController < ApplicationController
   end
 
   def search
+    # 検索に使用したワードを取得
     if params[:q].present?
       if params[:q][:comment_or_tags_name_cont].present?
         @search_ward = params[:q][:comment_or_tags_name_cont]
@@ -32,6 +40,7 @@ class PostsController < ApplicationController
   end
 
   def destroy
+    # ポスト削除の処理
     Post.find_by(id: params[:id]).destroy
     redirect_to profile_path(current_user.id), info: t(".delete.delete_post")
   end
@@ -43,6 +52,45 @@ class PostsController < ApplicationController
       format.js
     end
   end
+
+  def search_game
+    # httpリクエスト、Ajaxでレスポンスを返す用のライブラリを読み込み
+    require "net/http"
+    require "uri"
+    require "json"
+
+    # IGDBのAPIを使用してゲーム名を検索
+    uri = URI.parse("https://api.igdb.com/v4/games")
+    word = ' " ' + params[:word] + ' " '
+    request = Net::HTTP::Post.new(uri)
+    request["Content-Type"] = "text/plain"
+    request["Client-ID"] = ENV["IGDB_CLIENT_ID"]
+    request["Accept"] = "application/json"
+    request["Authorization"] = "Bearer #{ENV["IGDB_ACCESS_TOKEN"]}"
+
+    # 検索したい内容をリクエストに追加する(ゲーム名を検索し、検索結果にIDとゲーム名を取得、追加コンテンツの名前は削除)
+    request.body = "search #{word};
+    fields name, cover.image_id;
+    where category = (0,2,4,8,9,10,11) & version_parent = null;
+    limit 10;"
+
+    # 後で使う用のリクエスト文
+    # game_localizations.region, game_localizations.cover.image_id, game_localizations.name
+
+    # IGDBにリクエストを送信
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: true) do |http|
+      http.request(request)
+    end
+
+    # 取得したゲーム名とリージョンをJson形式に変換し、@gamesに代入
+    @games = JSON.parse(response.body)
+
+    # format.jsに@gamesのデータを入れてレスポンス設定
+    respond_to do |format|
+      format.js { render json: @games }
+    end
+  end
+
   private
 
   def post_params

--- a/app/javascript/search_game.js
+++ b/app/javascript/search_game.js
@@ -1,0 +1,47 @@
+var btn = document.getElementById('search_btn');
+      btn.addEventListener('click', function() {
+        event.preventDefault();
+  
+        $.ajax({
+              url: '/posts/search_game', 
+              type: 'POST',
+              data: $('form').serialize(),
+              dataType: 'json', 
+              success: function(response) {
+                $('.js-search_result div').remove();
+
+                if(response != ""){
+                $(response).each(function(i,message) {
+                  const japaneseCoverUrl = `https://images.igdb.com/igdb/image/upload/t_cover_big/${message["cover"]["image_id"]}.jpg`;
+                  
+                  $('.js-search_result').append(
+                    `<div class="card" data-bs-dismiss="modal">
+                      <div class="row g-0">
+                        <div class="col-md-2">
+                          <img class="game_icon" src="${japaneseCoverUrl}" width="80px" height="80px" >
+                        </div>
+                        <div class="col-md-8">
+                          <li class="game_name py-2 px-4" style="list-style: none;">${message["name"]}</li>
+                        </div>
+                      </div>
+                    </div>`
+                  );
+                });
+
+                $('.js-search_result').on('click', '.card', function() {
+                  const SelectGameName = $(this).find('.game_name').text();
+                  const SelectGameIcon = $(this).find('.game_icon').attr('src');
+                  $('#game_name').val(SelectGameName);
+                  $('#game_icon').val(SelectGameIcon);
+                });
+                } else {
+                  $('.js-search_result div').remove();
+                  $('.js-search_result').append(
+                  `<div>ゲームが見つかりませんでした。</div>`
+                  );
+                }
+              },
+              error: function() {
+              }
+          });
+        })

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -1,0 +1,19 @@
+class Game < ApplicationRecord
+  # ポストが削除されたら中間テーブルpost_gamesの関連データも削除
+  has_many :post_games, dependent: :destroy
+  # 中間テーブルpost_gamesを通してpostsと関連
+  has_many :posts, through: :post_games
+
+  # お気に入り解除されたら中間テーブルuser_gamesの関連データも削除
+  has_many :user_games, dependent: :destroy
+  # 中間テーブルuser_gamesを通してusersと関連
+  has_many :users, through: :user_games
+
+  # ぶっちゃけいらないかもだけど念のためバリデーションを作成
+  validates :name, presence: true, length: { maximum: 255 }
+
+  # ポスト検索する際、検索可能なカラムの追加
+  def self.ransackable_attributes(auth_object = nil)
+    [ "created_at", "id", "name", "updated_at" ]
+  end
+end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -6,6 +6,11 @@ class Post < ApplicationRecord
   # 中間テーブルpost_tagsを通してtagsと関連
   has_many :tags, through: :post_tags
 
+  # ポストが削除されたら中間テーブルpost_gamesの関連データも削除
+  has_many :post_games, dependent: :destroy
+  # 中間テーブルpost_gamesを通してgamesと関連
+  has_many :games, through: :post_games
+
   # 動画URL、コメントのモデル設定
   validates :movie_url, presence: true, length: { maximum: 255 }
   validates :comment, presence: true, length: { maximum: 255 }
@@ -17,7 +22,7 @@ class Post < ApplicationRecord
     # 正しいURLで入力されているかどうか、一応ライブ動画も対応
     if movie_url.present?
       if !movie_url.start_with?("https://youtu.be/") && !movie_url.start_with?("https://www.youtube.com/live/")
-        errors.add(:movie_url, "が正しくありません、YouTubeの共有ボタンからを取得してください") # save失敗のためにerror文、メッセージ対応は後で
+        errors.add(:movie_url, "が正しくありません、YouTubeの共有ボタンからを取得してください") # save失敗のためのerror文
       end
     end
   end
@@ -34,6 +39,11 @@ class Post < ApplicationRecord
       #   self.tags << post_tag
       # end
     end
+  end
+
+  def save_game(game_name, game_icon)
+    post_game = Game.find_or_create_by(name: game_name, icon: game_icon)
+    self.games << post_game
   end
 
   # ポスト検索する際、検索可能なカラムの追加

--- a/app/models/post_game.rb
+++ b/app/models/post_game.rb
@@ -1,0 +1,5 @@
+class PostGame < ApplicationRecord
+  # Post、Gameテーブルと関連
+  belongs_to :post
+  belongs_to :game
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -4,6 +4,11 @@ class User < ApplicationRecord
   # ポストと関連付け、このユーザーが削除されたらポストも削除
   has_many :posts, dependent: :destroy
 
+  # お気に入り解除されたら中間テーブルuser_gamesの関連データも削除
+  has_many :user_games, dependent: :destroy
+  # 中間テーブルuser_gamesを通してgamesと関連
+  has_many :games, through: :user_games
+
   # 中間テーブルFollowとの関連付け、「User多」対「User多」の関係となるがクラス名を宣言することで別々の関連付けの宣言にする
   has_many :following, class_name: "Follow", foreign_key: "following_id", dependent: :destroy
   has_many :follower, class_name: "Follow", foreign_key: "follower_id", dependent: :destroy

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -21,6 +21,8 @@
     <%= stylesheet_link_tag 'headers' %>
     <%= stylesheet_link_tag 'sidebars' %>
     <%= stylesheet_link_tag 'mains' %>
+    <!-- jqueryを読み込ませるためのスクリプト(ゲーム名検索用) -->
+    <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
   </head>
 
   <body>

--- a/app/views/posts/_form_game.erb
+++ b/app/views/posts/_form_game.erb
@@ -1,0 +1,1 @@
+<li class="message">${message["name"]}</li>

--- a/app/views/posts/_game_name.html.erb
+++ b/app/views/posts/_game_name.html.erb
@@ -1,0 +1,32 @@
+<head>
+  <!-- javascript読み込み用 -->>
+  <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
+</head>
+
+<div class="modal fade" id="GameSelect" tabindex="-1" aria-labelledby="GameSelectLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h1 class="modal-title fs-5" id="GameSelectLavel">ゲーム名を選択</h1>
+        <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+      <p>API仕様の都合上、英語名での検索のみ対応しています。<br>
+      お手数ですが英語名でゲームの検索をお願いします。</p>
+      <p>ゲームが見つからなければ無入力でも構いません。</p>
+      <%= form_with do |form| %>
+        <div class="d-flex">
+          <%= form.text_field :word, class: "form-control" %>
+          <%= form.submit "検索", id: "search_btn", class: "btn btn-primary", style: "width: 70px;" %>
+        </div>
+        <ul class="js-search_result" style="padding-left: 0;"></ul>
+      <% end %>
+    
+    <!-- ゲーム検索用のスクリプト -->
+      <script type="module">
+        import "search_game";
+      </script>
+      </div>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/multi.html.erb
+++ b/app/views/posts/multi.html.erb
@@ -1,5 +1,5 @@
 <% @search_tags.each do |tag| %>
-  <li class="py-2 px-4" role="option" data-autocomplete-value="<%= tag.id %>" data-autocomplete-label="<%= tag.name %>">
+  <li class="py-2 px-4" role="option" data-autocomplete-value="<%= tag.id %>" data-autocomplete-label="<%= tag.name %>" style="list-style: none;">
     <%= tag.name %>
   </li>
 <% end %>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -14,10 +14,21 @@
       <%= form.label :tag, style: "display: block" %>
       <%= form.text_field :tag, class: "form-control", placeholder: 'タグを複数つける場合、「タグ1,タグ2,タグ3,...」と「,」でタグを分けてください' %>
     </div>
+    <div class="mb-2">
+      <%= form.label :game_name, style: "display: block" %>
+      <div class="d-flex">
+        <button type="button" class="btn btn-light" data-bs-toggle="modal" data-bs-target="#GameSelect" style="width: 70px;">選択</button>
+        <%= form.text_field :game_name, class: "form-control", style: "background-color: white;", id: "game_name", placeholder: '選択を押してゲーム検索' %>
+        <%= form.hidden_field :game_icon, id: "game_icon" %>
+      </div>
+    </div>
 
     <div style="display: block;">
       <%= form.submit t('.submit'), class: "btn btn-primary"  %>
     </div>
   <% end %>
+  <%= render 'game_name' %>
 </div>
+
+
 

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -9,7 +9,7 @@
           <div data-controller="autocomplete" data-autocomplete-url-value="/posts/multi" role="combobox" style="position: relative;">
             <%= f.search_field :comment_or_tags_name_cont, class: 'form-control', placeholder: 'ポストを検索', data: { autocomplete_target: 'input' }, style: "width: 300px;" %>
             <%= f.hidden_field :tags_name, data: { autocomplete_target: 'hidden' } %>
-            <ul class="multi_search list-group bg-white" data-autocomplete-target="results" style="list-style: none; position: absolute;" ></ul>
+            <ul class="multi_search list-group bg-white" data-autocomplete-target="results" style="padding-left: 0; position: absolute;" ></ul>
           </div>
           <%= f.submit '検索', class: 'btn btn-primary', style: "width: 70px; height: 40px;" %>
         </div>

--- a/app/views/shared/_post.html.erb
+++ b/app/views/shared/_post.html.erb
@@ -1,4 +1,4 @@
-<div class="card">
+<div class="card postcard">
   <div class="row g-0">
     <!-- サムネイルの表示 -->
     <div class="col-md-3">

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -10,3 +10,4 @@ pin_all_from "app/javascript/controllers", under: "controllers"
 pin "popper", to: "popper.js", preload: true
 pin "bootstrap", to: "bootstrap.min.js", preload: true
 pin "stimulus-autocomplete" # @3.1.0
+pin "search_game", to: "search_game.js"

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -16,3 +16,4 @@ ja:
         movie_url: 動画URL
         comment: コメント
         tag: タグ
+        game_name: ゲーム名

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,7 @@ Rails.application.routes.draw do
   # ポスト検索画面のルーティング追加
   get "posts/search",  to: "posts#search"
   get "posts/multi",  to: "posts#multi"
+  post "posts/search_game",  to: "posts#search_game"
 
   # フォロー機能作成用のルーティング設定
   post "follow/:id" => "follow#follow", as: "follow"

--- a/db/migrate/20250215112016_create_tag.rb
+++ b/db/migrate/20250215112016_create_tag.rb
@@ -2,6 +2,7 @@ class CreateTag < ActiveRecord::Migration[7.2]
   def change
     create_table :tags do |t|
       t.string :name # タグの名前
+
       t.timestamps
     end
   end

--- a/db/migrate/20250310133436_create_game.rb
+++ b/db/migrate/20250310133436_create_game.rb
@@ -1,0 +1,10 @@
+class CreateGame < ActiveRecord::Migration[7.2]
+  def change
+    create_table :games do |t|
+      t.string :name # ゲーム名
+      t.string :icon # ゲームアイコン
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250310133518_create_user_game.rb
+++ b/db/migrate/20250310133518_create_user_game.rb
@@ -1,0 +1,10 @@
+class CreateUserGame < ActiveRecord::Migration[7.2]
+  def change
+    create_table :user_games do |t|
+      t.references :user, foreign_key: true # Userのデータを関連付ける
+      t.references :game, foreign_key: true # Gameのデータを関連付ける
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250310134337_create_post_game.rb
+++ b/db/migrate/20250310134337_create_post_game.rb
@@ -1,0 +1,10 @@
+class CreatePostGame < ActiveRecord::Migration[7.2]
+  def change
+    create_table :post_games do |t|
+      t.references :post, foreign_key: true # Postのデータを関連付ける
+      t.references :game, foreign_key: true # Gameのデータを関連付ける
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_02_22_055910) do
+ActiveRecord::Schema[7.2].define(version: 2025_03_10_134337) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -23,6 +23,13 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_22_055910) do
     t.index ["following_id"], name: "index_follows_on_following_id"
   end
 
+  create_table "games", force: :cascade do |t|
+    t.string "name"
+    t.string "icon"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "histories", force: :cascade do |t|
     t.bigint "user_id"
     t.bigint "post_id"
@@ -30,6 +37,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_22_055910) do
     t.datetime "updated_at", null: false
     t.index ["post_id"], name: "index_histories_on_post_id"
     t.index ["user_id"], name: "index_histories_on_user_id"
+  end
+
+  create_table "post_games", force: :cascade do |t|
+    t.bigint "post_id"
+    t.bigint "game_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["game_id"], name: "index_post_games_on_game_id"
+    t.index ["post_id"], name: "index_post_games_on_post_id"
   end
 
   create_table "post_tags", force: :cascade do |t|
@@ -57,6 +73,15 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_22_055910) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "user_games", force: :cascade do |t|
+    t.bigint "user_id"
+    t.bigint "game_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["game_id"], name: "index_user_games_on_game_id"
+    t.index ["user_id"], name: "index_user_games_on_user_id"
+  end
+
   create_table "users", force: :cascade do |t|
     t.string "name", null: false
     t.string "email", null: false
@@ -80,7 +105,11 @@ ActiveRecord::Schema[7.2].define(version: 2025_02_22_055910) do
   add_foreign_key "follows", "users", column: "following_id"
   add_foreign_key "histories", "posts"
   add_foreign_key "histories", "users"
+  add_foreign_key "post_games", "games"
+  add_foreign_key "post_games", "posts"
   add_foreign_key "post_tags", "posts"
   add_foreign_key "post_tags", "tags"
   add_foreign_key "posts", "users"
+  add_foreign_key "user_games", "games"
+  add_foreign_key "user_games", "users"
 end


### PR DESCRIPTION
・概要
ポスト投稿時、ゲーム情報を載せられるように機能を追加。
直接入力するとユーザーによってゲーム入力名が異なってくるため、IGDBと呼ばれる様々なゲーム情報が保管された海外のAPIを使用してゲーム名を検索できるようにした。
ただし日本語名検索が出来ない為、入力したいゲーム名を英語で検索する手間がある。

・確認方法
ログインを行った状態でトップページからポスト投稿画面へ遷移する。
ラベル「ゲーム名」に選択ボタンがあるのでクリックし、ゲーム名検索用のモーダルウィンドウを開く。
フォームに検索したい英語のゲーム名を入力し、目的のゲームが表示されたら項目をクリックする。
モーダルウィンドウが閉じ、ゲーム名のフォームに選択した情報が自動で入力されることを確認する。

・メモ
出来れば日本語名検索を行えないか色々模索してみたが、どうしてもchatGPTなど日本語名のゲーム名を英語名に変換できるAIを導入するという大幅な手間が発生してしまう為、一旦英語名でのみ検索ができるように実装。
こちらに関してはこれ以上の機能拡張を行うと他のタスクが何も手を付けられなくなる可能性が高い為、現状の機能で一旦キリをあげておく。

また今回は全く手を付けていないjavascriptを用いた為、少しAIに頼り気味なコードになってしまった。
なるべくシンプルなようにコードを整理してはいるが、AIに頼ったようなコードになってしまった感は否めない為、
今後javascriptが十分に身についたらこの辺りで実装したコードを改めて整理したいと思う。