### PR TITLE
閲覧した動画からおすすめ機能の追加

### DIFF
--- a/app/controllers/top_controller.rb
+++ b/app/controllers/top_controller.rb
@@ -1,4 +1,6 @@
 class TopController < ApplicationController
+  include PostsHelper # PostHelperをインクルード
+
   def index
     if logged_in?
       # 最新のポストを昇順でまとめておく
@@ -10,6 +12,54 @@ class TopController < ApplicationController
           follow_ids.push(follow.id)
         end
         @follow_posts = Post.where(user_id: follow_ids)
+      end
+      # 閲覧履歴のポストに記載されているタグ、ゲーム名、ユーザー名からオススメポストを取得
+      history_posts = History.where(user_id: current_user.id).order(updated_at: :desc).limit(5)
+      @recommend_posts = []
+      if history_posts.present?
+        history_posts.each do |history|
+          # 閲覧したポストに記載されたタグからポストを一件ずつ検索
+          get_tag_name(history.post_id).each do |tag|
+            # タグからポスト一覧を検索するが、自分が投稿したポストを検索結果から除外して1件だけ取得
+            tag_random_post = Post.joins(:tags).where(tags: { name: tag }).where.not(user_id: current_user.id).order("RANDOM()").first
+            # ポストがヒットした場合
+            if !tag_random_post.nil?
+              # 取得したポストが重複しない場合、ポスト情報を追加する
+              @recommend_posts.push(tag_random_post) unless @recommend_posts.include?(tag_random_post)
+            end
+          end
+
+          # 閲覧したポストに記載されたゲームからポストを一件検索
+          game = get_game_name(history.post_id)
+          game_random_post = Post.joins(:games).where(games: { name: game }).where.not(user_id: current_user.id).order("RANDOM()").first
+          # ポストがヒットした場合
+          if !game_random_post.nil?
+            @recommend_posts.push(game_random_post) unless @recommend_posts.include?(game_random_post)
+          end
+
+          # 閲覧したポストに記載されたユーザーからポストを一件検索
+          post = Post.find_by(id: history.post_id)
+          # 閲覧したポストが自分のポストでない場合
+          if post.user.name != current_user.name
+            user_random_post = Post.where(user_id: current_user.id).order("RANDOM()").first
+            # ポストがヒットした場合
+            if !user_random_post.nil?
+              @recommend_posts.push(user_random_post) unless @recommend_posts.include?(user_random_post)
+            end
+          end
+        end
+
+        # 閲覧履歴のポストから何も取得できなかった場合
+        if @recommend_posts.nil?
+          # 全ポストからランダムに10件取得
+          @recommend_posts = Post.order("RANDOM()").limit(10)
+        else
+          # 取得したポストをランダムに並び変える
+          @recommend_posts.shuffle!
+        end
+      else
+        # 全ポストからランダムに10件取得
+        @recommend_posts = Post.order("RANDOM()").limit(10)
       end
     else
       @before_login_posts = Post.joins(:user).where(users: { name: "こうへい(管理人)", email: "k.kou29sky26@gmail.com" }).to_a.sample(3)

--- a/app/helpers/posts_helper.rb
+++ b/app/helpers/posts_helper.rb
@@ -29,6 +29,7 @@ module PostsHelper
     URI(uri.path.split("/").last)  # URLに含まれている動画idを返す
   end
 
+  # ポストに貼られたタグ名を取得するメソッド
   def get_tag_name(id)
     @tag_names = []
     if PostTag.exists?(post_id: id)
@@ -37,6 +38,14 @@ module PostsHelper
       end
     end
     @tag_names
+  end
+
+  # ポストに貼られたゲーム名を取得するメソッド
+  def get_game_name(id)
+    if PostGame.exists?(post_id: id)
+      game = Game.find_by(id: PostGame.find_by(post_id: id).game_id).name
+    end
+    game
   end
 
   # ポストが表示された回数をカウントするメソッド

--- a/app/views/top/_after_login.html.erb
+++ b/app/views/top/_after_login.html.erb
@@ -1,21 +1,21 @@
 <ul class="nav nav-tabs">
-    <li class="nav-item">
-      <button class="nav-link" data-bs-toggle="tab" data-bs-target="#new_post" type="button">
-        新規投稿
-      </button>
-    </li>
     <li class="nav-item" style="flex: 1;">
       <button class="nav-link active"  data-bs-toggle="tab" data-bs-target="#follow_post" type="button">
         フォロー
       </button>
     </li>
+    <li class="nav-item">
+      <button class="nav-link" data-bs-toggle="tab" data-bs-target="#recommend_post" type="button">
+        おすすめ
+      </button>
+    </li>
+    <li class="nav-item">
+      <button class="nav-link" data-bs-toggle="tab" data-bs-target="#new_post" type="button">
+        新規投稿
+      </button>
+    </li>
   </ul>
   <div class="tab-content">
-    <div id="new_post" class="tab-pane">
-      <div class="post">
-        <%= render partial: 'shared/post', collection: @new_posts %>
-      </div>
-    </div>
     <div id="follow_post" class="tab-pane active">
       <div class="post">
         <% if @follow_posts.present? %>
@@ -26,4 +26,15 @@
         <% end %>
       </div>
     </div>
+    <div id="new_post" class="tab-pane">
+      <div class="post">
+        <%= render partial: 'shared/post', collection: @new_posts %>
+      </div>
+    </div>
+    <div id="recommend_post" class="tab-pane">
+      <div class="post">
+        <%= render partial: 'shared/post', collection: @recommend_posts %>
+      </div>
+    </div>
+    
   </div>


### PR DESCRIPTION
・概要
これまで閲覧した最新の5件のポストからタグ、ゲーム名、ユーザーを取得し、そこから関連性のあるポストを取得し、トップページに「おすすめ」タブ内に一覧で表示。
これにより今まで投稿されたポストの中からユーザーにとって興味のある動画に辿り着きやすくなるようにした。
またこれまで閲覧したポストがないユーザーに向けて、ランダムに全ポストから10件表示させることで興味のあるポストが見つけやすいように機能を追加。

・確認方法
ランダムなポストからYoutubeに遷移することで閲覧したポストを追加する。
トップページに戻り、閲覧したポストに関連性のあるポストがおすすめタブに表示されることを確認。
また、閲覧したポストがない状態でおすすめタブを開いた際、全ポストからランダムに10件表示されることを確認。