### PR TITLE
フォロー一覧ページの作成

### DIFF
--- a/app/assets/stylesheets/mains.css
+++ b/app/assets/stylesheets/mains.css
@@ -53,7 +53,7 @@
   }
 
   .profile_name .follower {
-    /* 名前表示の位置調整、上下だけゴリ押し気味 */
+    /* フォロワー表示の位置調整、上下だけゴリ押し気味 */
     margin: 0 0 0 10px;
     height: 100%;
     line-height: 120px;
@@ -242,6 +242,33 @@
     margin: 0 0 0 50px;
   }
 
+  /*---------- follow/listで使用 ---------*/
+
+  .gamecard .follow_icon{
+     /* プレビュー用のアイコン表示設定、基本はprofile/showで使ったものと同じ */
+    content: "";
+    display: block;
+    padding-top: 58%;
+    overflow: hidden;
+    margin: 10px auto;
+
+    height: 150px;
+    aspect-ratio: 1;
+
+    /* アイコンを円形にし、外線を追加 */
+    object-fit: cover;
+    border-radius: 50%;
+    padding: 1px;
+    border: 1px solid #333300;
+
+    background-color: white;
+  }
+
+  .gamecard .follow_count{
+    /* フォロワー数を薄く表示 */
+    font-weight: lighter;
+    font-size: 15px;
+  }
 
   /*---------- その他 -----------*/
 

--- a/app/controllers/follow_controller.rb
+++ b/app/controllers/follow_controller.rb
@@ -9,4 +9,13 @@ class FollowController < ApplicationController
     current_user.unfollow(params[:id])
     redirect_to profile_path(params[:id])
   end
+
+  def list
+    if User.find_by(id: current_user.id).following_user
+      @follows= []
+      User.find_by(id: current_user.id).following_user.each do |follow|
+        @follows.push(follow)
+      end
+    end
+  end
 end

--- a/app/views/follow/_follow.html.erb
+++ b/app/views/follow/_follow.html.erb
@@ -1,0 +1,17 @@
+<div class="card gamecard" style="width: 200px;">
+  <%= link_to profile_path(follow.id), style: "text-decoration: none; color: inherit;" do %>
+    <div class="card-img-top">
+      <div class="follow_icon">
+        <% if follow.icon.url.present? %>
+          <%= image_tag follow.icon.url, style: "height: 150px; width: 150px;" %>
+        <% else %>
+          <%= image_tag "DefaultUserIcon.png", style: "height: 150px; width: 150px;" %>
+        <% end %>
+      </div>
+    </div>
+    <div class="card-body">
+      <div class="card-title" style="text-align: center; font-weight: bold;"><%= follow.name %></div>
+      <div class="follow_count" style="text-align: center;"><%= follower_count(follow.follower_user) %>人のフォロワー</div>
+    </div>
+  <% end %>
+</div>

--- a/app/views/follow/list.html.erb
+++ b/app/views/follow/list.html.erb
@@ -1,0 +1,5 @@
+<h1>フォロー一覧</h1>
+
+<div class="d-flex">
+  <%= render partial: 'follow/follow', collection: @follows %>
+</div>

--- a/app/views/posts/_game_name.html.erb
+++ b/app/views/posts/_game_name.html.erb
@@ -1,5 +1,5 @@
 <head>
-  <!-- javascript読み込み用 -->>
+  <!-- javascript読み込み用 -->
   <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
 </head>
 

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -29,6 +29,3 @@
   <% end %>
   <%= render 'game_name' %>
 </div>
-
-
-

--- a/app/views/shared/_sidebar.html.erb
+++ b/app/views/shared/_sidebar.html.erb
@@ -7,17 +7,22 @@
           <%= link_to t('sidebar.post'), new_post_path, class: "btn btn-primary", style: "width: 70%;" %>
         </div>
         <hr style="color: white;">
-      <li class="sideber-nav nav-item">
-        <a class="nav-link" href="<%= list_games_path %>">
-          <span class="ml-2">ゲーム一覧</span>
+        <li class="sideber-nav nav-item">
+        <a class="nav-link" href="<%= follow_list_path %>">
+          <span class="ml-2">フォロー一覧</span>
         </a>
       </li>
-      <li class="sideber-nav nav-item">
-        <a class="nav-link" href="<%= posts_history_path %>">
-          <span class="ml-2">閲覧履歴</span>
-        </a>
-      </li>
-      <hr style="color: white;">
+        <li class="sideber-nav nav-item">
+          <a class="nav-link" href="<%= list_games_path %>">
+            <span class="ml-2">ゲーム一覧</span>
+          </a>
+        </li>
+        <li class="sideber-nav nav-item">
+          <a class="nav-link" href="<%= posts_history_path %>">
+            <span class="ml-2">閲覧履歴</span>
+          </a>
+        </li>
+        <hr style="color: white;">
       <% end %>
       <div class="term_and_privacy" style="text-align: center;">
         <%= link_to "利用規約", term_path, style: "text-decoration: none; color: white;" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   resources :password_resets, only: %i[new create edit update]
   # プロフィール画面のルーティング設定
   resources :profiles, only: %i[show edit update destroy]
+
   # 設定画面のルーティング設定
   resources :settings, only: %i[edit update destroy]
   # ポスト画面のルーティング設定
@@ -40,6 +41,8 @@ Rails.application.routes.draw do
   # フォロー機能作成用のルーティング設定
   post "follow/:id" => "follow#follow", as: "follow"
   post "unfollow/:id" => "follow#unfollow", as: "unfollow"
+  get "follow/list" =>  "follow#list"
+
 
   # 利用規約、プライバシーポリシーのルーティング設定
   resource :term, only: %i[show]


### PR DESCRIPTION
・概要
自分がフォローした一覧を見れるページを作成。
これによりフォロー管理が行えるようになったり、フォローした人のプロフィールページへすぐに飛べるようになった。
UI周りは前回作成したゲーム一覧をベースにしている。

・確認方法
フォローした人がいる状態で、サイドバーからフォロー一覧のページへ遷移する。
フォローした人の一覧が画面に表示され、フォロー情報をクリックするとその人のプロフィール画面へ遷移することを確認する。